### PR TITLE
fix: publie planning-api sur le port hôte 3001, pas 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,9 @@ services:
     restart: unless-stopped
     ports:
       # Publié sur l'hôte car le CGI de Web_Planning tourne nativement sous Apache
-      # sur le VPS (pas dans un conteneur), il appelle donc http://localhost:3000.
-      - "3000:3000"
+      # sur le VPS (pas dans un conteneur), il appelle donc http://localhost:3001.
+      # 3001 et non 3000 : le port 3000 est déjà pris par le conteneur MillstoneSteam.
+      - "3001:3000"
     volumes:
       # events.xml + webhooks.json : données réelles, persistées hors du conteneur.
       - ./api-data:/data


### PR DESCRIPTION
Découvert au déploiement de #79 : le port 3000 est déjà pris par le conteneur MillstoneSteam (`app`) sur le VPS, `docker compose up` échouait ("port is already allocated"). Seul le port publié côté hôte change, le port interne du conteneur reste 3000.