### PR TITLE
feat: restriction optionnelle à un salon pour une instance dev/test

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,19 @@
+################################################################
+# Instance de dev/test d'URbot — même code, jeton et cible différents.
+# Ne lance pas planning-api (pas besoin pour tester des commandes de
+# base, et éviterait un conflit de port avec l'instance de prod).
+################################################################
+services:
+  urbot-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: urbot-dev
+    restart: unless-stopped
+    volumes:
+      - ./.bot_token:/usr/local/src/URbot/.bot_token:ro
+    environment:
+      # Salon Discord auquel restreindre les réponses du bot (voir
+      # src/bot/urbot.py) — laisser vide/absent pour un comportement
+      # normal (tous les salons, comme la prod).
+      - RESTRICT_TO_CHANNEL_ID=1526011382418641079

--- a/src/bot/urbot.py
+++ b/src/bot/urbot.py
@@ -127,6 +127,21 @@ def main():
 
     logging.basicConfig(level=logging.INFO)
     ur_bot = URBot()
+
+    # Restreint le bot à un seul salon si RESTRICT_TO_CHANNEL_ID est défini
+    # (instance de dev/test) ; n'affecte pas la prod, qui ne définit pas
+    # cette variable. Vérification globale : s'applique à toutes les
+    # commandes de tous les cogs, sans toucher à leur code.
+    restrict_channel_id = os.environ.get('RESTRICT_TO_CHANNEL_ID')
+    if restrict_channel_id:
+        restrict_channel_id = int(restrict_channel_id)
+
+        @ur_bot.check
+        def restrict_to_channel(ctx):
+            return ctx.channel.id == restrict_channel_id
+
+        log(f"Restreint au salon {restrict_channel_id}")
+
     log("Loading cogs...")
     # adds the "cogs" folder to the import path
     sys.path.append(COGS_PATH)


### PR DESCRIPTION
Closes #81

`RESTRICT_TO_CHANNEL_ID` (variable d'env) ajoute une vérification globale discord.py (`bot.check`) qui s'applique à toutes les commandes de tous les cogs, sans toucher à leur code. Absente/vide = comportement inchangé (la prod ne la définit pas).

`docker-compose.dev.yml` : instance de dev, même Dockerfile/code que la prod, jeton et cible différents, sans `planning-api` (pas nécessaire pour tester des commandes de base, évite un conflit de port avec la prod).

Testé en local (build `--no-cache` + override du fichier local via volume) : sans la variable, comportement inchangé ; avec, le log de restriction apparaît et le chargement des cogs n'est pas affecté.