### PR TITLE
fix: MyContext.send() ne doit pas planter si la suppression du message échoue

### DIFF
--- a/src/urpy/my_commands.py
+++ b/src/urpy/my_commands.py
@@ -1,5 +1,6 @@
 from abc import ABC, ABCMeta, abstractmethod
 
+import discord
 from discord.ext import commands
 
 
@@ -117,5 +118,11 @@ class MyContext(commands.Context):
         if 'delete_after' not in kwargs:
             kwargs['delete_after'] = self.delete_after
 
-        await self.message.delete(delay=kwargs['delete_after'])
+        try:
+            # supprimer le message d'origine est cosmetique : si le bot n'a pas la
+            # permission "Gerer les messages" sur ce salon, on renonce plutot que de
+            # laisser l'exception avorter la commande avant l'envoi de la reponse.
+            await self.message.delete(delay=kwargs['delete_after'])
+        except discord.HTTPException:
+            pass
         await super().send(content, **kwargs)


### PR DESCRIPTION
## Résumé

- `MyContext.send()` (`src/urpy/my_commands.py`) enveloppe désormais `self.message.delete()` dans un `try/except discord.HTTPException`.
- Sans ce fix, `\$prez` (la seule commande à utiliser `delete_after=None`, donc le chemin de suppression immédiate et bloquante de discord.py) échoue **totalement en silence** si le bot n'a pas la permission *Gérer les messages* : l'exception `Forbidden` interrompt la commande avant l'envoi de la réponse.

Closes #85

## Test plan

- [ ] Vérifier sur l'instance dev que `\$prez` répond désormais (message d'erreur "channel not found" ou succès) même sans la permission *Gérer les messages*.