### PR TITLE
fix: empêche un cog en erreur de faire planter $version/$credit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /usr/local/src
 # processus d'assemblage réel plutôt que de dépendre d'un contexte de build
 # local qui devrait déjà contenir les 3 repos en sous-dossiers.
 ARG GIT_ORG=https://github.com/UnionRolistes
-RUN git clone --depth 1 -b fix/version-cmd-error-handling ${GIT_ORG}/Bot_Base.git Bot_Base \
+RUN git clone --depth 1 ${GIT_ORG}/Bot_Base.git Bot_Base \
  && git clone --depth 1 ${GIT_ORG}/Bot_Planning_python.git Bot_Planning_python \
  && git clone --depth 1 ${GIT_ORG}/Bot_Presentation.git Bot_Presentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /usr/local/src
 # processus d'assemblage réel plutôt que de dépendre d'un contexte de build
 # local qui devrait déjà contenir les 3 repos en sous-dossiers.
 ARG GIT_ORG=https://github.com/UnionRolistes
-RUN git clone --depth 1 ${GIT_ORG}/Bot_Base.git Bot_Base \
+RUN git clone --depth 1 -b fix/version-cmd-error-handling ${GIT_ORG}/Bot_Base.git Bot_Base \
  && git clone --depth 1 ${GIT_ORG}/Bot_Planning_python.git Bot_Planning_python \
  && git clone --depth 1 ${GIT_ORG}/Bot_Presentation.git Bot_Presentation
 

--- a/src/bot/cog_about.py
+++ b/src/bot/cog_about.py
@@ -30,15 +30,22 @@ class About(commands.Cog):
 
     async def send_info_msg(self, ctx, with_credits=False):
         """ Sends a message containing the names, version numbers [and credits] of all the services. """
-        # generates the descriptions for all the subservices of the bot
-        services = "\n\n".join(
-            formatted_template(templates, 'service_template.txt',
-                               name=colorize(cog.get_name(), HEADING_COLOR),
-                               version=colorize(cog.get_version(), COMMAND_COLOR),
-                               credits=colorize(cog.get_credits(), DESCRIPTION_COLOR) if with_credits else "")
-
-            for name, cog in self.bot.cogs.items() if isinstance(cog, MyCog)
-        )
+        # generates the descriptions for all the subservices of the bot ; un cog en erreur
+        # (template manquant, get_version()/get_credits() casse...) ne doit pas empecher
+        # l'affichage des autres cogs qui fonctionnent normalement
+        service_entries = []
+        for name, cog in self.bot.cogs.items():
+            if not isinstance(cog, MyCog):
+                continue
+            try:
+                service_entries.append(formatted_template(templates, 'service_template.txt',
+                                   name=colorize(cog.get_name(), HEADING_COLOR),
+                                   version=colorize(cog.get_version(), COMMAND_COLOR),
+                                   credits=colorize(cog.get_credits(), DESCRIPTION_COLOR) if with_credits else ""))
+            except Exception as e:
+                error_log(f"Impossible d'afficher les informations du service '{name}' :", e)
+                service_entries.append(colorize(f"{name} : indisponible", ERROR_COLOR))
+        services = "\n\n".join(service_entries)
 
         # sends the message. Les titres sont colores+soulignes via ANSI (HEADING_COLOR inclut
         # deja le code de soulignement) plutot que via des '====='/'-----' litteraux : les


### PR DESCRIPTION
Closes #90, résout aussi UnionRolistes/Bot_Planning_python#36.

Le try/except par-cog dans `send_info_msg()` protège l'affichage des autres services quand un cog échoue (template manquant, `get_version()`/`get_credits()` cassé...) — auparavant toute la commande plantait, y compris pour les cogs qui fonctionnent normalement.

**Testé sur urbot-dev** (cas nominal + panne simulée en renommant temporairement `service_template.txt`) :
- Nominal : `$version`/`$credit` inchangés, sortie colorée normale
- Panne simulée : `$credit` affiche toujours les infos du bot + les entrées disponibles, avec "Presentation : indisponible"/"Planning : indisponible" en rouge au lieu de planter silencieusement